### PR TITLE
Temporary Workaround for broken nav

### DIFF
--- a/src/components/SiteNav.astro
+++ b/src/components/SiteNav.astro
@@ -9,11 +9,11 @@ const {menu, generalSettings} = Astro.props;
     <div class="hamburger">&#9776;</div>
     <nav>
         <ul>
-        {menu.menuItems.nodes.map(menuItem => {
+        <!-- {menu.menuItems.nodes.map(menuItem => {
             return (<li>
                         <a href={menuItem.uri || '/'}>{menuItem.label}</a>
                     </li>)
-            })}
+            })} -->
         </ul>
     </nav>
 </header>

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -4,7 +4,7 @@ export async function navQuery(){
         headers: {'Content-Type':'application/json'},
         body: JSON.stringify({
             query: `{
-                menus(where: {location: PRIMARY}) {
+                menus {
                   nodes {
                     name
                     menuItems {


### PR DESCRIPTION
In WP 6.5.3, Menus have been deprecated in favor of Navigation #18 

With a brand new WordPress website, this (from lib/api.js) now fails:
`{ menus(where: {location: PRIMARY}) { nodes { name menuItems { nodes { uri url order label } } } } generalSettings { title url description } }`

The workaround is to remove the (where {location: PRIMARY}) from the above AND

From src/SiteNave.astro comment out
`{menu.menuItems.nodes.map(menuItem => { return (<li> <a href={menuItem.uri || '/'}>{menuItem.label}</a> </li>) })}`

Obviously, this means you temporarily will have no menu until a better solution is provided